### PR TITLE
开机优先于 dnsmasq 执行 + 判断是否安装dnsmasq-full

### DIFF
--- a/files/root/etc/init.d/dnsmasq-ipset
+++ b/files/root/etc/init.d/dnsmasq-ipset
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Author Qier LU <lvqier@gmail.com>
 
-START=55
+START=18
 
 gen_config_file() {
     local section="${1}"
@@ -25,7 +25,10 @@ gen_config_file() {
         then
             echo "server=/${domain}/${upstream_dns_server}" >> "${config_file_name}"
         fi
-        echo "ipset=/${domain}/${ipset_name}" >> "${config_file_name}"
+        if [ -z "`opkg list-installed | grep dnsmasq-full`" ]
+        then
+            echo "ipset=/${domain}/${ipset_name}" >> "${config_file_name}"
+        fi
     }
     config_list_foreach "${section}" "managed_domain" handle_domain
 }

--- a/files/root/etc/init.d/dnsmasq-ipset
+++ b/files/root/etc/init.d/dnsmasq-ipset
@@ -25,7 +25,7 @@ gen_config_file() {
         then
             echo "server=/${domain}/${upstream_dns_server}" >> "${config_file_name}"
         fi
-        if [ -z "`opkg list-installed | grep dnsmasq-full`" ]
+        if [ -n "`opkg list-installed | grep dnsmasq-full`" ]
         then
             echo "ipset=/${domain}/${ipset_name}" >> "${config_file_name}"
         fi


### PR DESCRIPTION
如果开机不在dnsmasq运行之前生成配置文件则配置文件失效；
如果不判断是否安装dnsmasq-full，则dnsmasq运行出错